### PR TITLE
Add convenience option function to set custom logger

### DIFF
--- a/db.go
+++ b/db.go
@@ -139,6 +139,13 @@ func SetCodec(c codec.Codec) Option {
 	}
 }
 
+func SetLogger(logger badger.Logger) Option {
+	return func(db *DB) error {
+		db.badgerOptions.Logger = logger
+		return nil
+	}
+}
+
 func SetBadgerOptions(o badger.Options) Option {
 	return func(db *DB) error {
 		db.badgerOptions = o


### PR DESCRIPTION
This adds a convenience function, same to `SetCodec` etc to set an alternative logger, such as [`logrus`](https://github.com/sirupsen/logrus) etc.

Currently it is possible this way:

```golang
path = "/tmp/foo"
options := badger.DefaultOptions(path)
options.Logger = logrus.New()
db, err = bow.Open(path, bow.SetBadgerOptions(options))
...
```

But also could be possible just this, if the case is to only swap quite verbose Badger's logging:
```go
path = "/tmp/foo"
db, err := bow.Open(path, bow.SetLogger(logrus.New()))
```
